### PR TITLE
Be more careful when adding delta

### DIFF
--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -928,7 +928,7 @@ fn apply_lookup(
         //
         // It should be possible to construct tests for both of these cases.
 
-        end = (end as isize + delta) as _;
+        end = end.saturating_add_signed(delta);
         if end < match_positions[idx] {
             // End might end up being smaller than match_positions[idx] if the recursed
             // lookup ended up removing many items.


### PR DESCRIPTION
Rust has helpful convenience methods for avoiding overflows with arithmetic and avoiding casts.

Closes #142.