### PR TITLE
Propose publishing a patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.20.1] - 2024-10-12
+### Changed
+- Update canonical repository location
+- Address Clippy lints
+
+### Fixed
+- Track HarfBuzz's signed/unsigned integer types to avoid overflows
+
 ## [0.20.0] - 2024-10-04
 ### Changed
 - Bump `ttf-parser`.
@@ -247,7 +255,8 @@ At this point, this is just a simple Rust bindings to a stripped down harfbuzz.
   Embedded harfbuzz relies only on internal TrueType implementation.
 - Most of the non-shaping harfbuzz API.
 
-[Unreleased]: https://github.com/harfbuzz/rustybuzz/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/harfbuzz/rustybuzz/compare/v0.20.1...HEAD
+[0.20.1]: https://github.com/harfbuzz/rustybuzz/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/harfbuzz/rustybuzz/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/harfbuzz/rustybuzz/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/harfbuzz/rustybuzz/compare/v0.17.0...v0.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "rustybuzz"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "bitflags",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustybuzz"
-version = "0.20.0"
+version = "0.20.1"
 authors = [
     "Caleb Maclennan <caleb@alerque.com>",
     "Laurenz Stampfl <laurenz.stampfl@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "rustybuzz"
 version = "0.20.0"
-authors = ["Yevhenii Reizner <razrfalcon@gmail.com>"]
+authors = [
+    "Caleb Maclennan <caleb@alerque.com>",
+    "Laurenz Stampfl <laurenz.stampfl@gmail.com>",
+    "Yevhenii Reizner <razrfalcon@gmail.com>",
+    "خالد حسني (Khaled Hosny) <khaled@aliftype.com>"
+]
 edition = "2021"
 description = "A complete harfbuzz shaping algorithm port to Rust."
 documentation = "https://docs.rs/rustybuzz/"


### PR DESCRIPTION
Since we have a bugfix for an actual crash caused by a type mismatch from the HarfBuzz version this is currently synced with, I am proposing a patch level release now. Syncing with HB 10.1.0 can happen whenever somebody gets around to doing the porting, but I don't see anything else upcoming that we need to wait for to ship this patch. Any objections to my going ahead and publishing this?