### PR TITLE
bench: switch to criterion

### DIFF
--- a/benches/.gitignore
+++ b/benches/.gitignore
@@ -1,0 +1,4 @@
+target
+perf.data
+perf.data.old
+Cargo.lock

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,6 +7,13 @@ edition = "2018"
 harfbuzz_rs = { git = "https://github.com/harfbuzz/harfbuzz_rs/", rev = "43f0fb5" }
 rustybuzz = { path = "../" }
 
+[dev-dependencies]
+criterion = "0.3"
+criterion-macro = "0.3"
+
 [features]
 default = ["hb"]
 hb = []
+
+[profile.bench]
+debug = 2

--- a/benches/measure.sh
+++ b/benches/measure.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export HARFBUZZ_SYS_NO_PKG_CONFIG=""
+
+# Using jq here would be best, however it's not installed by default on many systems, and this isn't a critical script.
+TEST_EXECUTABLE=$(
+    cargo +nightly bench \
+    --message-format=json \
+    --no-default-features --no-run | \
+        sed -n 's/^{"reason":"compiler-artifact".*"executable":"\([^"]*\)".*}$/\1/p'
+)
+
+exec perf record --call-graph dwarf -- "$TEST_EXECUTABLE" --bench --profile-time 5 "$@"


### PR DESCRIPTION
This is a "PR that could have been an issue," I'm opening this PR to determine if this is a direction that the project wants to take.

Switches the benchmark framework to Criterion. The default Rust std test framework has a hardcoded goal execution time of 1ms for each benchmark. This makes it unsuitable for sample-based profiling because the benchmark doesn't run for very long.

Adds a utility script to run tests under a profiler.