### PR TITLE
Bump wasmi crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ unicode-bidi-mirroring = "0.4.0"
 unicode-ccc = "0.4.0"
 unicode-properties = { version = "0.1.3", default-features = false, features = ["general-category"] }
 unicode-script = "0.5.2"
-wasmi = { version = "0.37.0", optional = true }
+wasmi = { version = "0.40.0", optional = true }
 log = "0.4.22"
 
 [dependencies.ttf-parser]


### PR DESCRIPTION
The wasmi dependency is only used for the non-default WASM shaper featuer. I built and ran tests with this so it is probably fine, but @asibahi I thought I'd run this by you to make sure there isn't some reason to hold this back.

This will need a lock file bump to go with it, but I'll sort that out on merge dependency on #152 and #153.
